### PR TITLE
pin official slack app to a previous working version 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ runs:
     - name: Send failure to Slack
       # Third-party action, pin to commit SHA!
       # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-      uses: slackapi/slack-github-action@813c9c190d6932b08456732c084e5fe5e02415c8
+      uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117
       env:
         SLACK_WEBHOOK_URL: ${{ inputs.SLACK_WEBHOOK_URL }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
I'm getting a weird error message when using the latest version of the official slack GHA: `File not found: '/home/runner/work/_actions/slackapi/slack-github-action/813c9c190d6932b08456732c084e5fe5e02415c8/dist/index.js'`. I'll pin it to the last knowing working version for now and take a look at it again later.